### PR TITLE
erigon: fix pprof port clashing

### DIFF
--- a/ansible/inventories/devnet-1/group_vars/erigon.yaml
+++ b/ansible/inventories/devnet-1/group_vars/erigon.yaml
@@ -30,9 +30,9 @@ erigon_container_command_extra_args:
   - --txpool.globalslots=10000
   - --log.console.verbosity=info
   - --log.dir.verbosity=debug
-  - --metrics
   - --pprof
-  - --pprof.port=6061
+  - --pprof.addr=0.0.0.0
+  - --pprof.port=6060
   - --torrent.download.rate=1gb
   - --el.block.downloader.v2
   - --p2p.protocol=68

--- a/ansible/inventories/devnet-2/group_vars/erigon.yaml
+++ b/ansible/inventories/devnet-2/group_vars/erigon.yaml
@@ -30,9 +30,9 @@ erigon_container_command_extra_args:
   - --txpool.globalslots=10000
   - --log.console.verbosity=info
   - --log.dir.verbosity=debug
-  - --metrics
   - --pprof
-  - --pprof.port=6061
+  - --pprof.addr=0.0.0.0
+  - --pprof.port=6060
   - --torrent.download.rate=1gb
   - --el.block.downloader.v2
   - --p2p.protocol=68


### PR DESCRIPTION
matches the root --metrics.addr and --metrics.port so both metrics and ppoof will run on the same port https://github.com/ethpandaops/ansible-collection-general/blob/master/roles/erigon/defaults/main.yaml#L57-L59
