### PR TITLE
chore(ci): bump syncoor client flags and images

### DIFF
--- a/.github/workflows/syncoor-devnet-2.yaml
+++ b/.github/workflows/syncoor-devnet-2.yaml
@@ -137,8 +137,7 @@ jobs:
         el-extra-args: >-
           ${{
             (matrix.el-client == 'besu') && '[
-              "--required-block=23115201=0x88b0d56cc14c5232cdf6238c7252ca953e505f2a44ee60374f2bafb18bf067bf",
-              "--bootnodes=enode://3ba5f46aa1a9d863de4ce5ff67ec46704c43b2a1d5100e272dbfec5e56b350113018d3e67c400f09db60d4ec55df025bd209802c67826717a33a48acbe13b305@157.180.14.226:30303"
+              "--required-block=23115201=0x88b0d56cc14c5232cdf6238c7252ca953e505f2a44ee60374f2bafb18bf067bf"
             ]' ||
             (matrix.el-client == 'erigon') && '[
               "--prune.mode=full",
@@ -147,8 +146,7 @@ jobs:
               "--bootnodes=enode://3ba5f46aa1a9d863de4ce5ff67ec46704c43b2a1d5100e272dbfec5e56b350113018d3e67c400f09db60d4ec55df025bd209802c67826717a33a48acbe13b305@157.180.14.226:30303"
             ]' ||
             (matrix.el-client == 'geth') && '[
-              "--eth.requiredblocks=23115201=0x88b0d56cc14c5232cdf6238c7252ca953e505f2a44ee60374f2bafb18bf067bf",
-              "--bootnodes=enode://3ba5f46aa1a9d863de4ce5ff67ec46704c43b2a1d5100e272dbfec5e56b350113018d3e67c400f09db60d4ec55df025bd209802c67826717a33a48acbe13b305@157.180.14.226:30303"
+              "--eth.requiredblocks=23115201=0x88b0d56cc14c5232cdf6238c7252ca953e505f2a44ee60374f2bafb18bf067bf"
             ]' ||
             (matrix.el-client == 'nethermind') && '[
               "--Init.DiscoveryEnabled=true",


### PR DESCRIPTION
- Defining the bootnodes is not required, because the ethereum package is already setting them.
- Updated reth image that supports `--required-block-hashes`